### PR TITLE
fix: [KAN-255] Error fetching the Chapter content in the Outline

### DIFF
--- a/src/components/shared/common/RichEditor.js
+++ b/src/components/shared/common/RichEditor.js
@@ -48,7 +48,8 @@ export default class RichTextEditor extends Component {
       editorStyle,
       toolbarStyle,
       initialValue,
-      initialHTMLText
+      initialHTMLText,
+      disabled
     } = this.props
 
     const containerStyles = [styles.editorContainer]
@@ -81,6 +82,7 @@ export default class RichTextEditor extends Component {
           initialContentHTML={initialText}
           onChange={this.handleOnChange}
           editorInitializedCallback={this.handleEditorInitialized}
+          disabled={disabled?true:false}
         />
         <RichToolbar
           style={toolbarStyles}

--- a/src/components/shared/outline/SceneCard.js
+++ b/src/components/shared/outline/SceneCard.js
@@ -8,7 +8,7 @@ import { Card, CardItem, View, Left, Right } from 'native-base'
 import { StyleSheet } from 'react-native'
 import { isTablet } from 'react-native-device-info'
 import RichTextEditor from '../RichTextEditor'
-import { Text } from '../common'
+import { RichEditor, Text } from '../common'
 import Metrics from '../../../utils/Metrics'
 import Colors from '../../../utils/Colors'
 
@@ -25,10 +25,11 @@ class SceneCard extends Component {
     const { card } = this.props
 
     return <View style={{padding: 16}}>
-      <RichTextEditor
+      <RichEditor
+      // <RichTextEditor
         initialValue={card.description}
         onChange={() => {}}
-        readOnly
+        disabled
       />
     </View>
   }


### PR DESCRIPTION
![Screenshot 2021-03-20 at 12 36 49 PM](https://user-images.githubusercontent.com/2232432/111862307-7cef3900-897a-11eb-862c-9dcaa352420f.png)


The previous outline was using WebView to load the content which was causing the issue. I have changed it to react-native-pell-rich-editor.  I am not sure if the WebView was used on Purpose.